### PR TITLE
custom title index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a custom ``Title`` indexer for Ticket types.
+  It contains more context information from thet ``ticket_title_generator``: Event title, ticket title and event start and end dates.
+  [thet]
+
 - Make the ``ticket_title_generator`` more robust against cases, where a corresponding event occurrence of a ticket occurence isn't available anymore.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Make the ``ticket_title_generator`` more robust against cases, where a corresponding event occurrence of a ticket occurence isn't available anymore.
+  [thet]
+
 - Add ``item_stock_warning_threshold``, like in ``bda.plone.shop.at.SharedStockExtender``.
   Refs: https://github.com/bluedynamics/bda.plone.shop/pull/63 
   [thet]

--- a/src/bda/plone/ticketshop/common.py
+++ b/src/bda/plone/ticketshop/common.py
@@ -81,7 +81,13 @@ def ticket_title_generator(obj):
                 u"There is no event occurrence traverser implementation for "
                 u"this kind of object."
             )
-        event = traverser.publishTraverse(getRequest(), obj.id)
+        try:
+            event = traverser.publishTraverse(getRequest(), obj.id)
+        except KeyError:
+            # Maybe the ticket occurrence isn't valid anymore because the
+            # event occurence doesn't exist anymore.
+            # Just ignore that case.
+            return ret
 
     elif ITicket.providedBy(event):
         event = aq_parent(event)

--- a/src/bda/plone/ticketshop/configure.zcml
+++ b/src/bda/plone/ticketshop/configure.zcml
@@ -18,6 +18,8 @@
   <include zcml:condition="installed Products.ATContentTypes" package=".at" />
   <include zcml:condition="installed plone.dexterity" package=".dx" />
 
+  <adapter name="Title" factory=".indexer.ticket_title_indexer" />
+
   <subscriber handler=".subscribers.ticket_wf_changed" />
 
   <adapter factory=".common.EventTickets" />

--- a/src/bda/plone/ticketshop/indexer.py
+++ b/src/bda/plone/ticketshop/indexer.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from bda.plone.ticketshop.common import ticket_title_generator
+from bda.plone.ticketshop.interfaces import ITicket
+from plone.indexer.decorator import indexer
+
+
+@indexer(ITicket)
+def ticket_title_indexer(obj):
+    return ticket_title_generator(obj)['title']


### PR DESCRIPTION
- Make the ticket_title_generator more robust against cases, where a corresponding event occurrence of a ticket occurence isn't available anymore.

- Add a custom ``Title`` indexer for Ticket types. It contains more context information from thet ``ticket_title_generator``: Event title, ticket title and event start and end dates.